### PR TITLE
Fix strings handling

### DIFF
--- a/Magic_RDR/RPF/StringTable.cs
+++ b/Magic_RDR/RPF/StringTable.cs
@@ -310,7 +310,11 @@ namespace Magic_RDR.RPF
                 reader.Position = dictionary3[entry.Key];
                 reader.Write(1342177280U | (uint)((ulong)dictionary1["TempOffset"] & 268435455UL));
                 reader.Position = dictionary1["TempOffset"];
-                reader.WriteBytes(Encoding.ASCII.GetBytes(entry.StrValue + "\0"));
+
+                // XST strings are decoded as UTF-8 in Read(), so use the same
+                // encoding when rebuilding the resource. ASCII silently replaced
+                // accented and other non-ASCII characters with question marks.
+                reader.WriteBytes(Encoding.UTF8.GetBytes(entry.StrValue + "\0"));
             }
 
             byte[] b = new byte[DataUtils.NumLeftTill((int)reader.Length, (int)AppGlobals.Platform)];

--- a/Magic_RDR/Viewers/StringTableViewerForm.cs
+++ b/Magic_RDR/Viewers/StringTableViewerForm.cs
@@ -249,14 +249,28 @@ namespace Magic_RDR.Viewers
         {
             StringTable st = new StringTable
             {
-                TableModValue = 101U
+                // These values are part of the resource header. Replacing them with
+                // defaults makes the rebuilt XST incompatible with the original.
+                TableModValue = this.Table.TableModValue
             };
+			st.SetVMT(this.Table.VMT);
             
             if (this.IsResource)
             {
                 foreach (ListViewItem item in this.listView.Items)
                 {
-                    st.AddEntry(item.SubItems[1].Text, item.SubItems[2].Text);
+                    int entryIndex;
+                    if (!int.TryParse(item.SubItems[0].Text, out entryIndex) ||
+                        entryIndex < 0 || entryIndex >= this.Table.Entries.Count)
+                    {
+                        return null;
+                    }
+
+                    // The key displayed by the viewer is already a numeric hash
+                    // (for example 0x1234ABCD). Passing that text to AddEntry(string,
+                    // string) hashes the display value again, so the game can no
+                    // longer find any of the strings in the rebuilt table.
+                    st.AddEntry(this.Table.Entries[entryIndex].Key, item.SubItems[2].Text);
                 }
             }
             else


### PR DESCRIPTION
Until now every single change in XST was broken - changes were do to XST, but strings were not displayed in game - all strings from modded XST completely disappeared from game. After this change I was finally able to modify "Go to saloon" string in intro01 with custom translated string on X360 RGH.